### PR TITLE
Worker broken pipe error fix

### DIFF
--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -41,7 +41,9 @@ def activity_task_loop(worker: Worker):
                 continue
             if err:
                 logger.error("PollForActivityTask failed: %s", err)
-                continue
+                logger.info(f"trying to restart worker and returning from current method")
+                worker.start()
+                return
             task_token = task.task_token
             if not task_token:
                 logger.debug("PollForActivityTask has no task_token (expected): %s", task)

--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -38,13 +38,13 @@ def activity_task_loop(worker: Worker):
                 return
             except Exception as ex:
                 logger.error("PollForActivityTask error: %s", ex)
-                continue
-            if err:
-                logger.error("PollForActivityTask failed: %s", err)
                 logger.info(f"trying to restart worker and returning from current method")
                 worker.stop()
                 worker.start()
                 return
+            if err:
+                logger.error("PollForActivityTask failed: %s", err)
+                continue
             task_token = task.task_token
             if not task_token:
                 logger.debug("PollForActivityTask has no task_token (expected): %s", task)

--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -38,10 +38,7 @@ def activity_task_loop(worker: Worker):
                 return
             except Exception as ex:
                 logger.error("PollForActivityTask error: %s", ex)
-                logger.info(f"trying to restart worker and returning from current method")
-                worker.stop()
-                worker.start()
-                return
+                raise
             if err:
                 logger.error("PollForActivityTask failed: %s", err)
                 continue

--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -42,6 +42,7 @@ def activity_task_loop(worker: Worker):
             if err:
                 logger.error("PollForActivityTask failed: %s", err)
                 logger.info(f"trying to restart worker and returning from current method")
+                worker.stop()
                 worker.start()
                 return
             task_token = task.task_token


### PR DESCRIPTION
Issue:
In case worker loses connection to cadence (say, due to cadence server restart etc), it doesn't try to re-establish the connection.
[I tried to fix](https://github.com/firdaus/cadence-python/pull/22) by letting the worker connect to cadence again - but it didn't work and threw other errors:
so - now thinking to kill the worker by raising exception so that the pod will restart and connect to cadence again